### PR TITLE
Adds Support for Passing the GPG Passphrase to gpg-import

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,6 +21,7 @@ dependencies:
       gpg_user: "{{ postgresql_backup_system_user }}"
       gpg_group: "{{ postgresql_backup_system_group }}"
       gpg_private_key: "{{ postgresql_backup_gpg_private_key }}"
+      gpg_private_key_passphrase: "{{ postgresql_backup_gpg_pass }}"
       gpg_public_key: "{{ postgresql_backup_gpg_public_key }}"
       gpg_trust_file: "{{ postgresql_backup_gpg_trust_file }}"
     when: postgresql_backup_enabled and postgresql_backup_import_gpg_keys


### PR DESCRIPTION
This PR adds support for passing the GPG passphrase to the
gpg-import role since it now supports that.

Related to https://github.com/onaio/ansible-gpg-import/pull/5

Signed-off-by: Jason Rogena <jason@rogena.me>