### PR TITLE
Forward GPG Keys to the Backup Role

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+postgresql_user_home: "/var/lib/postgresql"
+
 postgresql_backup_enabled: true
 
 # GPG Import
@@ -38,3 +40,5 @@ postgresql_backup_profiles:
     gpg_key: "{{ postgresql_backup_gpg_key_id }}"
     gpg_pw: "{{ postgresql_backup_gpg_pass }}"
     gpg_opts: "{{ postgres_backup_gpg_opts }}"
+    gpg_private_key_src: "{{ postgresql_backup_gpg_private_key }}"
+    gpg_public_key_src: "{{ postgresql_backup_gpg_public_key }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,7 @@
     gpg_private_key_passphrase: "{{ postgresql_backup_gpg_pass }}"
     gpg_public_key: "{{ postgresql_backup_gpg_public_key }}"
     gpg_trust_file: "{{ postgresql_backup_gpg_trust_file }}"
+    gpg_home: "{{ postgresql_user_home }}"
   when: postgresql_backup_enabled and postgresql_backup_import_gpg_keys
   tags:
     - backup


### PR DESCRIPTION
Since the backup role now needs the paths to the private and public keys
used to encrypt the backups, forward those from this role.

Signed-off-by: Jason Rogena <jason@rogena.me>