### PR TITLE
Changes the Default Opsgenie Host ID

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,15 +29,16 @@ postgresql_backup_target_protocol: "file"
 postgresql_backup_target_path: "/backups/postgresql"
 postgresql_backup_cron_filename: backup_postgresql
 postgresql_backup_opsgenie_api_key:
+postgresql_backup_opsgenie_host_id: "{{ ansible_host | default(inventory_hostname) }}"
 postgresql_backup_on_error_command: |
   curl -X POST https://api.opsgenie.com/v2/alerts \
       -H "Content-Type: application/json" \
       -H "Authorization: GenieKey {{ postgresql_backup_opsgenie_api_key }}" \
       -d \
   '{
-      "message": "PostgreSQL backups in {{ inventory_hostname }} failing",
-      "alias": "backups-{{ inventory_hostname }}-postgres",
-      "description":"PostgreSQL backups in {{ inventory_hostname }} are currently not running.",
+      "message": "PostgreSQL backups in {{ postgresql_backup_opsgenie_host_id }} failing",
+      "alias": "backups-{{ postgresql_backup_opsgenie_host_id | hash('sha1') }}-postgres",
+      "description":"PostgreSQL backups in {{ postgresql_backup_opsgenie_host_id }} are currently not running.",
       "priority":"P2"
   }'
 postgresql_backup_profiles:


### PR DESCRIPTION
Prefer the default host identifier in Opsgenie messages being
ansible_host then inventory_hostname since ansible_host will likely
identify the host better [1]. There are some situations where
inventory_hostname is set to the hostname of the host.

1 - https://docs.ansible.com/ansible/latest/reference_appendices/special_variables.html#connection-variables

Signed-off-by: Jason Rogena <jason@rogena.me>