### PR TITLE
Fix postgresql_ssl Disable Issue

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,7 @@ postgresql_backup_target: "{{ postgresql_backup_target_protocol }}://{{ postgres
 postgresql_ssl_cert_file: "{{ postgresql_ssl_directory }}/{{ postgresql_ssl_server_cert_filename }}"
 postgresql_ssl_key_file: "{{ postgresql_ssl_directory }}/{{ postgresql_ssl_server_key_filename }}"
 postgresql_ssl_ca_file: "{{ postgresql_ssl_directory }}/{{ postgresql_ssl_ca_cert_filename }}"
-postgresql_ssl: "{% if postgresql_enable_ssl %}on{% else %}off{% endif %}"
+postgresql_ssl: "{{ postgresql_enable_ssl }}"
 postgresql_service_user: "postgres"
 postgresql_service_uid: 119
 postgresql_service_group: "postgres"


### PR DESCRIPTION
Fix issue causing PostgreSQL's ssl configuration not to be
set to "off" when postgresql_enable_ssl is set to false.