### PR TITLE
Fix PostgreSQL Backups Permissions 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,6 +74,7 @@ postgresql_backup_profiles:
     full_max_age: "1W" # forces a full backup if last full backup reaches a specified age
     max_full_backups: 4 # Number of full backups to keep.
     user: "{{ postgresql_backup_system_user }}"
+    group: "{{ postgresql_backup_system_group }}"
     gpg_key: "{{ postgresql_backup_gpg_key_id }}"
     gpg_pw: "{{ postgresql_backup_gpg_pass }}"
     gpg_opts: "{{ postgres_backup_gpg_opts }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
     certificates_system_owner: "{{ postgresql_service_user }}"
     certificates_system_group: "{{ postgresql_service_group }}"
     certificates_file_mode: 0700
-  when: postgresql_enable_ssl
+  when: postgresql_enable_ssl|bool
   tags:
     - tls
     - postgresql_tls
@@ -48,7 +48,7 @@
     owner: "{{ postgresql_backup_system_user }}"
     group: "{{ postgresql_backup_system_group }}"
     mode: 0750
-  when: postgresql_backup_enabled and postgresql_backup_target_protocol == "file"
+  when: postgresql_backup_enabled|bool and postgresql_backup_target_protocol == "file"
   tags:
     - backup
 
@@ -56,7 +56,7 @@
   file:
     path: "{{ postgresql_backup_target_path | dirname }}"
     mode: "a+x"
-  when: postgresql_backup_enabled and postgresql_backup_target_protocol == "file"
+  when: postgresql_backup_enabled|bool and postgresql_backup_target_protocol == "file"
   tags:
     - backup
 
@@ -70,7 +70,7 @@
     gpg_public_key: "{{ postgresql_backup_gpg_public_key }}"
     gpg_trust_file: "{{ postgresql_backup_gpg_trust_file }}"
     gpg_home: "{{ postgresql_user_home }}"
-  when: postgresql_backup_enabled and postgresql_backup_import_gpg_keys
+  when: postgresql_backup_enabled|bool and postgresql_backup_import_gpg_keys|bool
   tags:
     - backup
 
@@ -82,6 +82,27 @@
     backup_profiles: "{{ postgresql_backup_profiles }}"
     backup_target_user: "{{ postgresql_backup_target_user }}"
     backup_target_pass: "{{ postgresql_backup_target_pass }}"
-  when: postgresql_backup_enabled
+  when: postgresql_backup_enabled|bool
   tags:
     - backup
+
+- include_role:
+    name: onaio.ssl-certificate
+  vars:
+    certificate_authority_key: "{{ postgresql_ssl_ca_key }}"
+    certificate_authority_cert: "{{  postgresql_ssl_ca_cert }}"
+    certificates_directory: "{{ postgresql_ssl_directory }}"
+    certificate_authority_key_filename: "{{ postgresql_ssl_ca_key_filename }}"
+    certificate_authority_cert_filename: "{{ postgresql_ssl_ca_cert_filename }}"
+    client_key_filename: "{{ postgresql_ssl_server_key_filename }}"
+    client_csr_filename: "{{ postgresql_ssl_server_csr_filename }}"
+    client_cert_filename: "{{ postgresql_ssl_server_cert_filename }}"
+    certificate_expiry_days: "{{ postgresql_ssl_server_cert_expiry_days }}"
+    certificate_attributes: "{{ postgresql_ssl_server_cert_subject }}"
+    certificates_system_owner: "postgres"
+    certificates_system_group: "postgres"
+    certificates_file_mode: 0700
+  when: postgresql_enable_ssl|bool
+  tags:
+    - tls
+    - postgresql_tls

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,6 +79,7 @@
   vars:
     backup_cron_filename: "{{ postgresql_backup_cron_filename }}"
     backup_enabled: "{{ postgresql_backup_enabled }}"
+    backup_user: "{{ postgresql_backup_system_user }}"
     backup_profiles: "{{ postgresql_backup_profiles }}"
     backup_target_user: "{{ postgresql_backup_target_user }}"
     backup_target_pass: "{{ postgresql_backup_target_pass }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,11 @@
 
 - include_role:
     name: ANXS.postgresql
+  vars:
+    postgresql_ext_postgis_deps:
+      - libgeos-c1v5
+      - "postgresql-{{ postgresql_version }}-postgis-{{ postgresql_ext_postgis_version }}"
+      - "postgresql-{{ postgresql_version }}-postgis-{{ postgresql_ext_postgis_version }}-scripts"
 
 - name: Make sure the backup directory exists
   file:


### PR DESCRIPTION
**Based on the work from**  #17

When using the default backup user, backups fail with permission denied error because the root user creates and owns the backup directory.

Specifying a `backup_user` when importing the backup role fixes this problem, as the root directory is now owned by the same user running the backups